### PR TITLE
enabled always rebuilding

### DIFF
--- a/single_iwyu.py
+++ b/single_iwyu.py
@@ -105,7 +105,7 @@ def perform_iwyu(fixer_path: Path, part: json, filters: List[Path], current_path
         return False
     
     finally:
-        preprocess_file.unlink()
+        preprocess_file.unlink(missing_ok=True)
 
     with open(outfile.with_suffix('.c'), encoding='utf-8') as file:
         lines = file.readlines()


### PR DESCRIPTION
Resolves #35 by always rebuilding the .i file instead of using one if it already exists. This is a problem because if we modify string.c and add another header. It will take the old.i instead of rebuilding and may even say no change in size.