### PR TITLE
raise warn on double modification

### DIFF
--- a/single_iwyu.py
+++ b/single_iwyu.py
@@ -91,7 +91,7 @@ def perform_iwyu(fixer_path: Path, part: json, filters: List[Path], current_path
     quote_cleaner = ['python', f'{current_path}/lib/remove_quotes.py']
     fix_includes = [f'{fixer_path}', '--noreorder']
 
-    #Runs twice to fix include list once and a second time to catch bad includes
+    # Runs twice to fix include list once and a second time to catch bad includes
     if not run_cleaned_iwyu(iwyu_cmd, quote_cleaner, fix_includes):
         warn("NO CHANGES")
         return False


### PR DESCRIPTION
We should run twice and if there is a modification both times that is usually indicative of header modification or xmacros so we should notify the user if there is a change twice.