### PR TITLE
this stops quotes from being replaced

### DIFF
--- a/lib/remove_quotes.py
+++ b/lib/remove_quotes.py
@@ -3,15 +3,22 @@
 import sys
 def replace_quotes_with_angle_brackets(text):
     '''Replaces odd " with < and even " with >'''
-    result = []
     replace_with = '<'
-    for char in text:
-        if char == '"':
-            result.append(replace_with)
-            replace_with = '>' if replace_with == '<' else '<'
+    text = text.split('\n')
+    formatted = []
+    for line in text:
+        if '/' in line and '..' not in line:
+            result = []
+            for char in line:
+                if char == '"':
+                    result.append(replace_with)
+                    replace_with = '>' if replace_with == '<' else '<'
+                else:
+                    result.append(char)
+            formatted.append(''.join(result))
         else:
-            result.append(char)
-    return ''.join(result)
+            formatted.append(line)
+    return '\n'.join(formatted)
 
 if __name__ == "__main__":
     print(replace_quotes_with_angle_brackets(sys.stdin.read()))


### PR DESCRIPTION
Closes #39 
We currently replace local headers with <> which is bad. Kernel local headers have two settings:
they either don't have '/' or they have '../' this checks for both of them and prevents local headers from being turned to <> headers.