### PR TITLE
Infers arg type from extension

### DIFF
--- a/build_intermediary.py
+++ b/build_intermediary.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
                         help='Number of threads',
                         default=1)
     parser.add_argument('-e', '--extension', type=str,
-                        help='File extension type .i, .ll, .o etc',
+                        help='File extension type .i, .ll, .s, or .bc',
                         default='.i')
 
     args = parser.parse_args()


### PR DESCRIPTION
Before we had a -a where the user could give an additional arg, now we infer it from the extension type.