### PR TITLE
Created additional arch specific filter

### DIFF
--- a/auto-iwyu.py
+++ b/auto-iwyu.py
@@ -12,13 +12,21 @@ def main(commands, fixer_path, filters):
     with open(commands, encoding="utf-8") as file:
         data = json.load(file)
         count = 0
+        skipped = False
         for part in data:
             count += 1
             print(count, part["file"])
+            if not ".c" in part["file"]:
+                continue
+            if "core.c" in part["file"]:
+                skipped = True
+                continue
+            if not skipped:
+                continue
             if not "arch" in part["file"] and not perform_iwyu(
                 fixer_path,
                 part,
-                filters + [Path(current_dir), "nonarch.imp"],
+                filters + [Path(current_dir, "nonarch.imp")],
                 current_dir,
             ):
                 continue

--- a/auto-iwyu.py
+++ b/auto-iwyu.py
@@ -14,8 +14,15 @@ def main(commands, fixer_path, filters):
         count = 0
         for part in data:
             count += 1
-            print(count)
-            if not perform_iwyu(fixer_path, part, filters, current_dir):
+            print(count, part["file"])
+            if not "arch" in part["file"] and not perform_iwyu(
+                fixer_path,
+                part,
+                filters + [Path(current_dir), "nonarch.imp"],
+                current_dir,
+            ):
+                continue
+            elif not perform_iwyu(fixer_path, part, filters, current_dir):
                 return
 
 

--- a/filter.imp
+++ b/filter.imp
@@ -112,4 +112,5 @@
    { include: ["@.asm(-generic)?/early_ioremap.h.", private, "<linux/io.h>", "public"] },
    { include: ["@.asm-generic/mman-common.h.", private, "<asm/mman.h>", "public"] },
    { include: ["@.asm-generic/mshyperv.h.", private, "<asm/mshyperv.h>", "public"] },
+   { include: ["@.asm-generic/param.h.", private, "<asm/param.h>", "public"] },
 ]

--- a/filter.imp
+++ b/filter.imp
@@ -96,8 +96,8 @@
 
 
    # The below headers were added by hand due to errors being found when the private headers were included.
-   # Additionally, If an asm header has no asm-generic version like pgtable_64_types we can use a
-   # non-architecture specific header instead
+   # Additionally, If an asm header has no asm-generic version and is not present in every architecture 
+   # like pgtable_64_types we can use a non-architecture specific header instead
    { include: ["@.asm-generic/signal-defs.h.", private, "<linux/signal.h>", "public"] },
    { include: ["@.asm-generic/bitops*.", private, "<linux/bitops.h>", "public"] },
    { include: ["@.asm/percpu.h.", private, "<linux/percpu.h>", "public"] },

--- a/filter.imp
+++ b/filter.imp
@@ -96,20 +96,11 @@
 
 
    # The below headers were added by hand due to errors being found when the private headers were included.
-   # Additionally, If an asm header has no asm-generic version and is not present in every architecture 
-   # like pgtable_64_types we can use a non-architecture specific header instead
    { include: ["@.asm-generic/signal-defs.h.", private, "<linux/signal.h>", "public"] },
    { include: ["@.asm-generic/bitops*.", private, "<linux/bitops.h>", "public"] },
    { include: ["@.asm/percpu.h.", private, "<linux/percpu.h>", "public"] },
    { include: ["@.asm-generic/errno-base.h.", private, "<linux/errno.h>", "public"] },
    { include: ["@.asm-generic/int-ll64.h.", private, "<linux/types.h>", "public"] },
-   { include: ["@.asm/page_types.h.", private, "<asm/page.h>", "public"] },
-   { include: ["@.asm/pgtable_64_types.h.", private, "<asm/pgtable.h>", "public"] },
-   { include: ["@.asm/pgtable_types.h.", private, "<asm/pgtable.h>", "public"] },
-   { include: ["@.asm/page_64.h.", private, "<asm/page.h>", "public"] },
-   { include: ["@.asm/page_32.h.", private, "<asm/page.h>", "public"] },
-   { include: ["@.asm/string_64.h.", private, "<linux/string.h>", "public"] },
-   { include: ["@.asm-generic/param.h.", private, "<asm/param.h>", "public"] },
    { include: ["@.asm(-generic)?/resource.h.", private, "<linux/resource.h>", "public"] },
    { include: ["@.asm-generic/memory_model.h.", private, "<asm/page.h>", "public"] }, 
    { include: ["@.asm-generic/access_ok.h.", private, "<linux/uaccess.h>", "public"] }, 

--- a/filter.imp
+++ b/filter.imp
@@ -96,17 +96,8 @@
 
 
    # The below headers were added by hand due to errors being found when the private headers were included.
-   { include: ["@.asm/bitsperlong.h.", private, "<linux/bits.h>", "public"] },
-   { include: ["@.asm/errno.h.", private, "<linux/errno.h>", "public"] },
-   { include: ["@.asm/resource.h.", private, "<linux/resource.h>", "public"] },
    { include: ["@.asm-generic/signal-defs.h.", private, "<linux/signal.h>", "public"] },
    { include: ["@.asm/signal.h.", private, "<linux/signal.h>", "public"] },
-   { include: ["@.asm-generic/bitops*.", private, "<linux/bitops.h>", "public"] },
-   { include: ["@.asm/bug.h.", private, "<linux/bug.h>", "public"] },
-   { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },
-   { include: ["@.asm/io.h.", private, "<linux/io.h>", "public"] },
-   { include: ["@.asm/kprobes.h.", private, "<linux/kprobes.h>", "public"] },
-   { include: ["@.asm/module.h.", private, "<linux/module.h>", "public"] },
    { include: ["@.asm/pci.h.", private, "<linux/pci.h>", "public"] },
    { include: ["@.asm/percpu.h.", private, "<linux/percpu.h>", "public"] },
    { include: ["@.asm/timex.h.", private, "<linux/timex.h>", "public"] },
@@ -128,11 +119,7 @@
    { include: ["@.asm-generic/siginfo.h.", private, "<asm/siginfo.h>", "public"] }, 
    { include: ["@.asm-generic/div64.h.", private, "<asm/div64.h>", "public"] }, 
    { include: ["@.asm-generic/fcntl.h.", private, "<asm/fcntl.h>", "public"] },
-   { include: ["@.asm/pti.h.", private, "<linux/pti.h>", "public"] },
-   { include: ["@.asm/pci.h.", private, "<linux/pci.h>", "public"] }, 
-   { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
    { include: ["@.asm(-generic)?/early_ioremap.h.", private, "<linux/io.h>", "public"] },
    { include: ["@.asm-generic/mman-common.h.", private, "<asm/mman.h>", "public"] },
    { include: ["@.asm-generic/mshyperv.h.", private, "<asm/mshyperv.h>", "public"] },
-   { include: ["@.asm/tsc.h.", private, "<linux/timex.h>", "public"] },
 ]

--- a/filter.imp
+++ b/filter.imp
@@ -96,6 +96,8 @@
 
 
    # The below headers were added by hand due to errors being found when the private headers were included.
+   # Additionally, If a header is architecture specific like pgtable_64_types we can use a non-architecture
+   # specific header instead
    { include: ["@.asm-generic/signal-defs.h.", private, "<linux/signal.h>", "public"] },
    { include: ["@.asm-generic/bitops*.", private, "<linux/bitops.h>", "public"] },
    { include: ["@.asm/percpu.h.", private, "<linux/percpu.h>", "public"] },

--- a/filter.imp
+++ b/filter.imp
@@ -97,11 +97,8 @@
 
    # The below headers were added by hand due to errors being found when the private headers were included.
    { include: ["@.asm-generic/signal-defs.h.", private, "<linux/signal.h>", "public"] },
-   { include: ["@.asm/signal.h.", private, "<linux/signal.h>", "public"] },
-   { include: ["@.asm/pci.h.", private, "<linux/pci.h>", "public"] },
+   { include: ["@.asm-generic/bitops*.", private, "<linux/bitops.h>", "public"] },
    { include: ["@.asm/percpu.h.", private, "<linux/percpu.h>", "public"] },
-   { include: ["@.asm/timex.h.", private, "<linux/timex.h>", "public"] },
-   { include: ["@.asm/uaccess.h.", private, "<linux/uaccess.h>", "public"] },
    { include: ["@.asm-generic/errno-base.h.", private, "<linux/errno.h>", "public"] },
    { include: ["@.asm-generic/int-ll64.h.", private, "<linux/types.h>", "public"] },
    { include: ["@.asm/page_types.h.", private, "<asm/page.h>", "public"] },

--- a/filter.imp
+++ b/filter.imp
@@ -96,8 +96,8 @@
 
 
    # The below headers were added by hand due to errors being found when the private headers were included.
-   # Additionally, If a header is architecture specific like pgtable_64_types we can use a non-architecture
-   # specific header instead
+   # Additionally, If an asm header has no asm-generic version like pgtable_64_types we can use a
+   # non-architecture specific header instead
    { include: ["@.asm-generic/signal-defs.h.", private, "<linux/signal.h>", "public"] },
    { include: ["@.asm-generic/bitops*.", private, "<linux/bitops.h>", "public"] },
    { include: ["@.asm/percpu.h.", private, "<linux/percpu.h>", "public"] },

--- a/nonarch.imp
+++ b/nonarch.imp
@@ -1,13 +1,13 @@
 [
     # The following headers do not exist in every architecture and should be replaced
-    # if the .c file is not arch-specific
+    # if the .c file is not arch-specific, otherwise it is ok to include these
+    # asm/.h headers in arch/ .c files.
     { include: ["@.asm/page_types.h.", private, "<asm/page.h>", "public"] },
     { include: ["@.asm/pgtable_64_types.h.", private, "<asm/pgtable.h>", "public"] },
     { include: ["@.asm/pgtable_types.h.", private, "<asm/pgtable.h>", "public"] },
     { include: ["@.asm/page_64.h.", private, "<asm/page.h>", "public"] },
     { include: ["@.asm/page_32.h.", private, "<asm/page.h>", "public"] },
     { include: ["@.asm/string_64.h.", private, "<linux/string.h>", "public"] },
-    { include: ["@.asm-generic/param.h.", private, "<asm/param.h>", "public"] },
 
     # If an asm header has an asm-generic version or is present in every architecture 
     # like bug.h we should use the linux version of the header instead

--- a/nonarch.imp
+++ b/nonarch.imp
@@ -8,12 +8,11 @@
     { include: ["@.asm/page_64.h.", private, "<asm/page.h>", "public"] },
     { include: ["@.asm/page_32.h.", private, "<asm/page.h>", "public"] },
     { include: ["@.asm/string_64.h.", private, "<linux/string.h>", "public"] },
+    { include: ["@.asm/tsc.h.", private, "<linux/timex.h>", "public"] },
 
-    # If an asm header has an asm-generic version, or is present in every architecture 
-    # like bug.h, we should use the linux version of the header instead.
-    { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
+    # If an asm header has an asm-generic like bug.h, we should use the linux
+    # version of the header instead.
     { include: ["@.asm/bug.h.", private, "<linux/bug.h>", "public"] },
-    { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },
     { include: ["@.asm/io.h.", private, "<linux/io.h>", "public"] },
     { include: ["@.asm/kprobes.h.", private, "<linux/kprobes.h>", "public"] },
     { include: ["@.asm/module.h.", private, "<linux/module.h>", "public"] },
@@ -24,6 +23,11 @@
     { include: ["@.asm/pci.h.", private, "<linux/pci.h>", "public"] },
     { include: ["@.asm/timex.h.", private, "<linux/timex.h>", "public"] },
     { include: ["@.asm/uaccess.h.", private, "<linux/uaccess.h>", "public"] },
+
+    # If an asm header is present in every architecture we should use the
+    # linux version of the header instead
+    { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
+    { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },
     { include: ["@.asm/pti.h.", private, "<linux/pti.h>", "public"] },
-    { include: ["@.asm/tsc.h.", private, "<linux/timex.h>", "public"] },
+    
 ]

--- a/nonarch.imp
+++ b/nonarch.imp
@@ -2,7 +2,6 @@
     #If the directory is not architecture specific, add this filter to avoid
     #excess asm inclusions
     { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
-    { include: ["@.asm-generic/bitops*.", private, "<linux/bitops.h>", "public"] },
     { include: ["@.asm/bug.h.", private, "<linux/bug.h>", "public"] },
     { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },
     { include: ["@.asm/io.h.", private, "<linux/io.h>", "public"] },

--- a/nonarch.imp
+++ b/nonarch.imp
@@ -1,0 +1,20 @@
+[
+    #If the directory is not architecture specific, add this filter to avoid
+    #excess asm inclusions
+    { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
+    { include: ["@.asm-generic/bitops*.", private, "<linux/bitops.h>", "public"] },
+    { include: ["@.asm/bug.h.", private, "<linux/bug.h>", "public"] },
+    { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },
+    { include: ["@.asm/io.h.", private, "<linux/io.h>", "public"] },
+    { include: ["@.asm/kprobes.h.", private, "<linux/kprobes.h>", "public"] },
+    { include: ["@.asm/module.h.", private, "<linux/module.h>", "public"] },
+    { include: ["@.asm/bitsperlong.h.", private, "<linux/bits.h>", "public"] },
+    { include: ["@.asm/errno.h.", private, "<linux/errno.h>", "public"] },
+    { include: ["@.asm/resource.h.", private, "<linux/resource.h>", "public"] },
+    { include: ["@.asm/signal.h.", private, "<linux/signal.h>", "public"] },
+    { include: ["@.asm/pci.h.", private, "<linux/pci.h>", "public"] },
+    { include: ["@.asm/timex.h.", private, "<linux/timex.h>", "public"] },
+    { include: ["@.asm/uaccess.h.", private, "<linux/uaccess.h>", "public"] },
+    { include: ["@.asm/pti.h.", private, "<linux/pti.h>", "public"] },
+    { include: ["@.asm/tsc.h.", private, "<linux/timex.h>", "public"] },
+]

--- a/nonarch.imp
+++ b/nonarch.imp
@@ -9,8 +9,8 @@
     { include: ["@.asm/page_32.h.", private, "<asm/page.h>", "public"] },
     { include: ["@.asm/string_64.h.", private, "<linux/string.h>", "public"] },
 
-    # If an asm header has an asm-generic version or is present in every architecture 
-    # like bug.h we should use the linux version of the header instead
+    # If an asm header has an asm-generic version, or is present in every architecture 
+    # like bug.h, we should use the linux version of the header instead.
     { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
     { include: ["@.asm/bug.h.", private, "<linux/bug.h>", "public"] },
     { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },

--- a/nonarch.imp
+++ b/nonarch.imp
@@ -1,6 +1,16 @@
 [
-    # If the directory is not architecture specific, add this filter to avoid
-    # excess asm inclusions
+    # The following headers do not exist in every architecture and should be replaced
+    # if the .c file is not arch-specific
+    { include: ["@.asm/page_types.h.", private, "<asm/page.h>", "public"] },
+    { include: ["@.asm/pgtable_64_types.h.", private, "<asm/pgtable.h>", "public"] },
+    { include: ["@.asm/pgtable_types.h.", private, "<asm/pgtable.h>", "public"] },
+    { include: ["@.asm/page_64.h.", private, "<asm/page.h>", "public"] },
+    { include: ["@.asm/page_32.h.", private, "<asm/page.h>", "public"] },
+    { include: ["@.asm/string_64.h.", private, "<linux/string.h>", "public"] },
+    { include: ["@.asm-generic/param.h.", private, "<asm/param.h>", "public"] },
+
+    # If an asm header has an asm-generic version or is present in every architecture 
+    # like bug.h we should use the linux version of the header instead
     { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
     { include: ["@.asm/bug.h.", private, "<linux/bug.h>", "public"] },
     { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },

--- a/nonarch.imp
+++ b/nonarch.imp
@@ -1,6 +1,6 @@
 [
-    #If the directory is not architecture specific, add this filter to avoid
-    #excess asm inclusions
+    # If the directory is not architecture specific, add this filter to avoid
+    # excess asm inclusions
     { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
     { include: ["@.asm/bug.h.", private, "<linux/bug.h>", "public"] },
     { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },

--- a/nonarch.imp
+++ b/nonarch.imp
@@ -9,6 +9,7 @@
     { include: ["@.asm/page_32.h.", private, "<asm/page.h>", "public"] },
     { include: ["@.asm/string_64.h.", private, "<linux/string.h>", "public"] },
     { include: ["@.asm/tsc.h.", private, "<linux/timex.h>", "public"] },
+    { include: ["@.asm/pti.h.", private, "<linux/pti.h>", "public"] },
 
     # If an asm header has an asm-generic like bug.h, we should use the linux
     # version of the header instead.
@@ -28,6 +29,5 @@
     # linux version of the header instead
     { include: ["@.asm/ptrace.h.", private, "<linux/ptrace.h>", "public"] }, 
     { include: ["@.asm/delay.h.", private, "<linux/delay.h>", "public"] },
-    { include: ["@.asm/pti.h.", private, "<linux/pti.h>", "public"] },
     
 ]

--- a/single_iwyu.py
+++ b/single_iwyu.py
@@ -26,7 +26,7 @@ def main(commands: Path, fixer_path: Path, filters: List[Path], specific: str):
                 perform_iwyu(
                     fixer_path,
                     part,
-                    filters + [Path(current_dir), "nonarch.imp"],
+                    filters + [Path(current_dir, "nonarch.imp")],
                     current_dir,
                     debug=DEBUG,
                 )

--- a/single_iwyu.py
+++ b/single_iwyu.py
@@ -22,7 +22,7 @@ def main(commands: Path, fixer_path: Path, filters: List[Path], specific: str):
         if len(eligible) == 0:
             warn("NO FILE WITH IDENTIFIER FOUND")
         for part in eligible:
-            if not "linux/arch/" in part["file"]:
+            if not "/arch/" in part["file"]:
                 perform_iwyu(
                     fixer_path,
                     part,

--- a/single_iwyu.py
+++ b/single_iwyu.py
@@ -22,7 +22,16 @@ def main(commands: Path, fixer_path: Path, filters: List[Path], specific: str):
         if len(eligible) == 0:
             warn("NO FILE WITH IDENTIFIER FOUND")
         for part in eligible:
-            perform_iwyu(fixer_path, part, filters, current_dir, debug=DEBUG)
+            if not "arch" in part["file"]:
+                perform_iwyu(
+                    fixer_path,
+                    part,
+                    filters + [Path(current_dir), "nonarch.imp"],
+                    current_dir,
+                    debug=DEBUG,
+                )
+            else:
+                perform_iwyu(fixer_path, part, filters, current_dir, debug=DEBUG)
 
 
 if __name__ == "__main__":

--- a/single_iwyu.py
+++ b/single_iwyu.py
@@ -22,7 +22,7 @@ def main(commands: Path, fixer_path: Path, filters: List[Path], specific: str):
         if len(eligible) == 0:
             warn("NO FILE WITH IDENTIFIER FOUND")
         for part in eligible:
-            if not "arch" in part["file"]:
+            if not "linux/arch/" in part["file"]:
                 perform_iwyu(
                     fixer_path,
                     part,


### PR DESCRIPTION
Currently filter.imp always uses linux instead of asm if possible. In the arch directory it is acceptable to use asm. This PR breaks the part of filter.imp out into nonarch.imp and includes it in non arch directories.

Resolves #67 